### PR TITLE
Fix crash with centrifuge output

### DIFF
--- a/src/main/java/com/resourcefulbees/resourcefulbees/tileentity/multiblocks/centrifuge/CentrifugeControllerTileEntity.java
+++ b/src/main/java/com/resourcefulbees/resourcefulbees/tileentity/multiblocks/centrifuge/CentrifugeControllerTileEntity.java
@@ -151,7 +151,7 @@ public class CentrifugeControllerTileEntity extends TileEntity implements ITicka
                 JsonElement count = recipe.ingredient.serialize().getAsJsonObject().get(BeeConstants.INGREDIENT_COUNT);
                 int inputAmount = count != null ? count.getAsInt() : 1;
 
-                return inventoryHasSpace() && glass_bottle.getItem() == Items.GLASS_BOTTLE && energyStorage.getEnergyStored() >= recipe.time * Config.RF_TICK_CENTRIFUGE.get() && combs.getCount() >= inputAmount && glass_bottle.getCount() >= recipe.outputs.get(2).getLeft().getCount();
+                return inventoryHasSpace(recipe.outputs.get(0).getLeft()) && glass_bottle.getItem() == Items.GLASS_BOTTLE && energyStorage.getEnergyStored() >= recipe.time * Config.RF_TICK_CENTRIFUGE.get() && combs.getCount() >= inputAmount && glass_bottle.getCount() >= recipe.outputs.get(2).getLeft().getCount();
             }else return false;
         }
         return false;
@@ -167,7 +167,7 @@ public class CentrifugeControllerTileEntity extends TileEntity implements ITicka
                 for(int i = 0; i < 3; i++){
                     Pair<ItemStack, Float> output = recipe.outputs.get(i);
                     if (output.getRight() >= world.rand.nextDouble()) {
-                        if (inventoryHasSpace()) {
+                        if (inventoryHasSpace(output.getLeft().copy())) {
                             depositItemStacks(output.getLeft().copy());
                             if (i == 2) glass_bottle.shrink(recipe.outputs.get(2).getLeft().getCount());
                         }
@@ -231,10 +231,18 @@ public class CentrifugeControllerTileEntity extends TileEntity implements ITicka
     }
 
 
-    public boolean inventoryHasSpace(){
-        for (int i=4; i < 22; ++i){
-            if (h.getStackInSlot(i).isEmpty()){
-                return true;
+    public boolean inventoryHasSpace(ItemStack stack) {
+        int needed = 0;
+        int count = stack.copy().getCount();
+        while (count > 0) {
+            needed += 1;
+            count -= stack.getMaxStackSize();
+        }
+        int has = 0;
+        for (int i = 4; i < 22; ++i) {
+            if (h.getStackInSlot(i).isEmpty()) {
+                has++;
+                if (has >= needed) return true;
             }
         }
         return false;


### PR DESCRIPTION
This PR fixes #44.
It counts how many slots are needed for the output and stops progress if output is too full. This is only needed for recipes with more than 1 stack output. Honey bottles are still "deleted" if output is full.
Something to "fix" it would be an internal cache. An array of ItemStacks which will put in the next available output slot when it's available. This has a higher priority then the normal recipe. If you decide to implement the "cache", you could revert my changes here or just not merge them.