### PR TITLE
Add beehives tag for bee_nest

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/beehives.json
+++ b/src/main/resources/data/minecraft/tags/blocks/beehives.json
@@ -5,6 +5,7 @@
     "resourcefulbees:t2_beehive",
     "resourcefulbees:t3_beehive",
     "resourcefulbees:t4_beehive",
+    "resourcefulbees:bee_nest",
     "resourcefulbees:acacia_bee_nest",
     "resourcefulbees:jungle_bee_nest",
     "resourcefulbees:grass_bee_nest",


### PR DESCRIPTION
This is the only one that doesn't have `minecraft:beehives`, so can't be used to craft tier 1 hives.