### PR TITLE
Add Cookielicious compat

### DIFF
--- a/src/main/resources/data/cookielicious/tags/items/sandwich_cookies.json
+++ b/src/main/resources/data/cookielicious/tags/items/sandwich_cookies.json
@@ -1,0 +1,6 @@
+{
+	"replace": "false",
+	"values": [
+		"resourcefulbees:oreo_cookie"
+	]
+}


### PR DESCRIPTION
Hello! I am a dev on the Cookielicious mod, and one of our users asked for compatibility between our mod and this one in an issue (Evoslab/Cookielicious#12). This PR adds the oreo cookie to a tag our mod uses and should allow us to close the issue.
Thank you!