### PR TITLE
Fix #130

### DIFF
--- a/src/main/java/com/resourcefulbees/resourcefulbees/utils/validation/ValidatorUtils.java
+++ b/src/main/java/com/resourcefulbees/resourcefulbees/utils/validation/ValidatorUtils.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 import static com.resourcefulbees.resourcefulbees.ResourcefulBees.LOGGER;
 
 public class ValidatorUtils {
-    public static final Pattern SINGLE_RESOURCE_PATTERN = Pattern.compile("^([\\w,\\-,\\.]+):([\\w,\\-,\\.,\\/]+)$", Pattern.CASE_INSENSITIVE);
+    public static final Pattern SINGLE_RESOURCE_PATTERN = Pattern.compile("^([\\w\\-\\.]+):([\\w\\-\\.\\/]+)$", Pattern.CASE_INSENSITIVE);
     public static final Pattern TAG_RESOURCE_PATTERN = Pattern.compile("^(tag:)(\\w+):(\\w+/\\w+|\\w+)$", Pattern.CASE_INSENSITIVE);
     public static final Pattern ENTITY_RESOURCE_PATTERN = Pattern.compile("^(entity:)(\\w+):(\\w+/\\w+|\\w+)$", Pattern.CASE_INSENSITIVE);
 

--- a/src/main/java/com/resourcefulbees/resourcefulbees/utils/validation/ValidatorUtils.java
+++ b/src/main/java/com/resourcefulbees/resourcefulbees/utils/validation/ValidatorUtils.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 import static com.resourcefulbees.resourcefulbees.ResourcefulBees.LOGGER;
 
 public class ValidatorUtils {
-    public static final Pattern SINGLE_RESOURCE_PATTERN = Pattern.compile("^(\\w+):(\\w+)$", Pattern.CASE_INSENSITIVE);
+    public static final Pattern SINGLE_RESOURCE_PATTERN = Pattern.compile("^([\\w,\\-,\\.]+):([\\w,\\-,\\.,\\/]+)$", Pattern.CASE_INSENSITIVE);
     public static final Pattern TAG_RESOURCE_PATTERN = Pattern.compile("^(tag:)(\\w+):(\\w+/\\w+|\\w+)$", Pattern.CASE_INSENSITIVE);
     public static final Pattern ENTITY_RESOURCE_PATTERN = Pattern.compile("^(entity:)(\\w+):(\\w+/\\w+|\\w+)$", Pattern.CASE_INSENSITIVE);
 


### PR DESCRIPTION
Adjust SINGLE_RESOURCE_PATTERN matcher to accept all valid characters for namespaced identifiers (- and . for both namespace and name, / for name only)

Individually adds the hyphen, dot, and slash into a character set with the word character, since, as far as I know, there is no existing class that includes them all.

Verified to be working, screenshot shows centrifuge outputting the Mana and Artifice Runeforge
![image](https://user-images.githubusercontent.com/10690571/104869409-f5eaf980-5913-11eb-9cb5-08de01fdd57f.png)
