### PR TITLE
Prevent bee nests from generating on water

### DIFF
--- a/src/main/java/com/resourcefulbees/resourcefulbees/world/BeeNestFeature.java
+++ b/src/main/java/com/resourcefulbees/resourcefulbees/world/BeeNestFeature.java
@@ -77,6 +77,9 @@ public class BeeNestFeature extends Feature<NoFeatureConfig> {
         } else {
             y = worldIn.getHeight(Heightmap.Type.WORLD_SURFACE_WG, pos.getX(), pos.getZ());
             newPos = new BlockPos(pos.getX(), y, pos.getZ());
+            if (!worldIn.getBlockState(newPos.down()).getFluidState().isEmpty()) {
+                return false;
+            }
         }
 
         if (newPos.getY() == 0) {


### PR DESCRIPTION
I've added a check to prevent bee nests from generating on top of liquids, as it looks very out of place when they do. I didn't touch the nether generation, because from looking at the code it seems to be at least somewhat intentional that nests can spawn on lava.